### PR TITLE
Allow development version to be specified via command-line

### DIFF
--- a/ggitflow-maven-archetype/pom.xml
+++ b/ggitflow-maven-archetype/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.dkirrane.maven.plugins</groupId>
         <artifactId>ggitflow-maven</artifactId>
-        <version>3.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.dkirrane.maven.archetype</groupId>
     <artifactId>ggitflow-maven-archetype</artifactId>
-    <version>3.0</version>
+    <version>4.0-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>ggitflow-maven-archetype</name>
 

--- a/ggitflow-maven-plugin/pom.xml
+++ b/ggitflow-maven-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.dkirrane.maven.plugins</groupId>
         <artifactId>ggitflow-maven</artifactId>
-        <version>3.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.dkirrane.maven.plugins</groupId>
     <artifactId>ggitflow-maven-plugin</artifactId>
-    <version>3.0</version>
+    <version>4.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>ggitflow-maven-plugin</name>
 
@@ -95,8 +95,8 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
             <version>2.0.0.0</version>
-        </dependency>     
-        
+        </dependency>
+
 
         <dependency>
             <groupId>junit</groupId>

--- a/ggitflow-maven-plugin/src/main/java/com/dkirrane/maven/plugins/ggitflow/ReleaseStartMojo.java
+++ b/ggitflow-maven-plugin/src/main/java/com/dkirrane/maven/plugins/ggitflow/ReleaseStartMojo.java
@@ -56,7 +56,7 @@ public class ReleaseStartMojo extends AbstractReleaseMojo {
 
     /**
      * The version to set in the develop branch.  If not specified, the version is determined by either
-     * prompting (is interactive is true) or calculated by incrementing the last digit in the current version.
+     * prompting (if interactive is true) or calculated by incrementing the last digit in the current version.
      */
     @Parameter(property = "developmentVersion", required = false)
     protected String developmentVersion;

--- a/ggitflow-maven-plugin/src/test/java/com/dkirrane/maven/plugins/ggitflow/ReleaseStartMojoTest.java
+++ b/ggitflow-maven-plugin/src/test/java/com/dkirrane/maven/plugins/ggitflow/ReleaseStartMojoTest.java
@@ -1,0 +1,90 @@
+package com.dkirrane.maven.plugins.ggitflow;
+
+import java.io.IOException;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dkirrane.maven.plugins.ggitflow.prompt.PrompterImpl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class ReleaseStartMojoTest {
+
+    private static final String CURRENT_DEVELOPMENT_VERSION = "1.1.0-SNAPSHOT";
+    protected ReleaseStartMojoStub releaseStartMojoStub;
+
+    @Before
+    public void setup() {
+
+        releaseStartMojoStub = new ReleaseStartMojoStub();
+    }
+    @Test
+    public void should_use_development_version_from_mojo_property() throws MojoFailureException, MojoExecutionException {
+        String developmentVersion = "1.2.0-SNAPSHOT";
+        releaseStartMojoStub.setDevelopmentVersion(developmentVersion);
+        String nextDevelopmentVersion = releaseStartMojoStub.getNextDevelopVersion(CURRENT_DEVELOPMENT_VERSION);
+        assertThat(nextDevelopmentVersion, is(developmentVersion));
+    }
+
+    @Test
+    public void should_use_calculated_development_version() throws MojoFailureException, MojoExecutionException {
+        releaseStartMojoStub.session = createNonInteractiveMavenSession();
+        String nextDevelopVersion = releaseStartMojoStub.getNextDevelopVersion(CURRENT_DEVELOPMENT_VERSION);
+        assertThat(nextDevelopVersion, is("1.1.1-SNAPSHOT"));
+    }
+
+    @Test
+    public void should_use_development_version_from_prompt() throws IOException, MojoExecutionException {
+        releaseStartMojoStub.session= createInteractiveMavenSession();
+
+        String stubbedPromptResponse = "1.83.0-SNAPSHOT";
+        releaseStartMojoStub.prompter = new PrompterStub(stubbedPromptResponse);
+
+        String nextDevelopVersion = releaseStartMojoStub.getNextDevelopVersion(CURRENT_DEVELOPMENT_VERSION);
+        assertThat(nextDevelopVersion, is(stubbedPromptResponse));
+
+    }
+
+    private MavenSession createNonInteractiveMavenSession() {
+        boolean interactive = false;
+        return createMavenSession(interactive);
+    }
+
+    private MavenSession createInteractiveMavenSession() {
+        boolean interactive = true;
+        return createMavenSession(interactive);
+    }
+
+    private MavenSession createMavenSession(boolean interactive) {
+        DefaultMavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setInteractiveMode(interactive);
+        return new MavenSession(null, null, request, null);
+    }
+
+
+    class PrompterStub extends PrompterImpl {
+
+        private String stubbedPromptResponse;
+
+        public PrompterStub(String stubbedPromptResponse) throws IOException {
+            this.stubbedPromptResponse = stubbedPromptResponse;
+        }
+
+        @Override
+        public String promptWithDefault(String message, String defaultValue) throws IOException {
+            return stubbedPromptResponse;
+        }
+    }
+    class ReleaseStartMojoStub extends ReleaseStartMojo {
+
+        void setDevelopmentVersion(String developmentVersion) {
+            this.developmentVersion=developmentVersion;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.dkirrane.maven.plugins</groupId>
     <artifactId>ggitflow-maven</artifactId>
-    <version>3.0</version>
+    <version>4.0-SNAPSHOT</version>
     <name>ggitflow-maven</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
To facilitate automation, we'd like to be able to specify the next development version as a maven property upon release-start.  As of now, it is not possible in non-interactive mode to provide next development version, and the default strategy of incrementing the last digit may not be suitable for all teams.

example execution:
`$ mvn gitflow:release-start -DdevelopmentVersion=1.2.0-SNAPSHOT`

The documentation should be updated to include "developmentVersion" as an additional property for this goal.
Although these commits include changes to the <version> of pom.xmls, please feel free to set these per your release process.

Thanks!